### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,7 +1339,7 @@ This work is done at [**Berkeley Sky Computing Lab**](https://sky.cs.berkeley.ed
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=yichuan-w/LEANN&type=Date)](https://www.star-history.com/#yichuan-w/LEANN&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=yichuan-w/LEANN&type=Date)](https://star-history.dera.page/#yichuan-w/LEANN&Date)
 <p align="center">
   <strong>⭐ Star us on GitHub if Leann is useful for your research or applications!</strong>
 </p>


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub's stargazer API restrictions. This change repoints the chart at star-history.dera.page, a mirror that needs no API token and serves the chart from the same domain as the frontend.