### PR TITLE
fix(sync): include .pdf in default sync extension allowlist

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -310,7 +310,11 @@ jobs:
           fi
           retry 5 uv pip install --python "$BUILD_PY" scikit-build-core numpy swig Cython pybind11
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            retry 5 uv pip install --python "$BUILD_PY" auditwheel
+            # auditwheel >= 6.0 requires patchelf >= 0.14.5, but ubuntu-22.04's
+            # apt only ships 0.14.3 — install a newer one from PyPI into the
+            # build venv (its bin dir is prepended to PATH below, so it wins
+            # over /usr/bin/patchelf).
+            retry 5 uv pip install --python "$BUILD_PY" auditwheel "patchelf>=0.14.5"
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             retry 5 uv pip install --python "$BUILD_PY" delocate
           else

--- a/packages/leann-core/src/leann/sync.py
+++ b/packages/leann-core/src/leann/sync.py
@@ -14,6 +14,7 @@ DEFAULT_INDEX_EXTENSIONS: list[str] = [
     ".md",
     ".docx",
     ".pptx",
+    ".pdf",
     ".py",
     ".js",
     ".ts",

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -78,6 +78,34 @@ class TestFileSynchronizer(unittest.TestCase):
             assert len(result) == 1
             assert str((root / "code.py").resolve()) in result
 
+    def test_generate_file_hashes_includes_pdf_by_default(self):
+        # Regression test: PDFs are indexed by `leann build` by default, so they
+        # must also be covered by the default sync allowlist. Without this, a
+        # PDF-only directory yields zero hashes, detect_changes() reports no new
+        # files, and the first build exits early with "Index up to date."
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            pdf = root / "doc.pdf"
+            pdf.write_bytes(b"%PDF-1.4 fake")
+            fs = FileSynchronizer(root_dir=temp_dir, auto_load=False)
+            result = fs.generate_file_hashes()
+            assert str(pdf.resolve()) in result
+
+    def test_detect_changes_reports_pdf_as_added_on_first_build(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            snapshot = root / "sync.pickle"
+            docs = root / "docs"
+            docs.mkdir()
+            pdf = docs / "manual.pdf"
+            pdf.write_bytes(b"%PDF-1.4 fake")
+
+            fs = FileSynchronizer(root_dir=str(docs), snapshot_path=str(snapshot))
+            added, removed, modified = fs.detect_changes()
+            assert [str(pdf.resolve())] == added
+            assert removed == []
+            assert modified == []
+
     def test_generate_file_hashes_explicit_files_only(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## What does this PR do?

`leann build` indexes PDFs by default (`should_process_pdfs` in cli.py), but
`DEFAULT_INDEX_EXTENSIONS` in sync.py — the allowlist used by change detection
for incremental builds and `leann watch` — includes `.docx`/`.pptx` yet not
`.pdf`. The allowlist's own comment says to keep it in sync with build's
default extension set.

Consequences:

- A PDF-only directory hashes to an empty set, so `detect_changes()` reports
  no new files and the **first** build exits early with `Index up to date.`,
  leaving behind an empty index directory (shown as ❌ by `leann list`).
- PDF additions/modifications/removals are invisible to incremental builds
  and `leann watch`; only `--force` rebuilds pick them up.

Fix: add the missing `.pdf` to `DEFAULT_INDEX_EXTENSIONS`, plus regression
tests covering PDF hashing and first-build change detection.

Note: #299 fixed the same symptom for multi-document files skipped by
`len(file) > 1`, and #377 rewrote hashing to raw bytes — but the rewrite
moved file selection to this extension allowlist, which is where PDFs were
dropped. This PR closes that gap. Affected: main and the 0.3.8 tag.

## Related Issues

Relates to #290, #14

## Checklist

- [x] Tests pass (`uv run pytest`) — test_sync.py 10/10; the 3 failures in
  test_incremental_build.py are pre-existing on origin/main (identical
  failure set with and without this change)
- [x] Code formatted (`ruff format` and `ruff check`)
- [ ] Pre-commit hooks pass (`pre-commit run --all-files`)
