### PR TITLE
fix(ci): install compatible patchelf for auditwheel

### DIFF
--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -310,7 +310,7 @@ jobs:
           fi
           retry 5 uv pip install --python "$BUILD_PY" scikit-build-core numpy swig Cython pybind11
           if [[ "$RUNNER_OS" == "Linux" ]]; then
-            retry 5 uv pip install --python "$BUILD_PY" auditwheel
+            retry 5 uv pip install --python "$BUILD_PY" auditwheel "patchelf>=0.14.5"
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             retry 5 uv pip install --python "$BUILD_PY" delocate
           else


### PR DESCRIPTION
## What does this PR do?

Installs `patchelf>=0.14.5` alongside `auditwheel` in Linux wheel-build jobs.

The Ubuntu runners provide patchelf 0.14.3, while the current auditwheel repair step requires 0.14.5 or newer. This caused every Linux wheel build to fail during `auditwheel repair` after packages had built successfully.

## Related Issues

N/A

## Validation

- `pre-commit run check-yaml --files .github/workflows/build-reusable.yml`
- Installed the same `auditwheel` and `patchelf>=0.14.5` combination in a clean virtual environment; verified `patchelf 0.19.1` and `auditwheel 6.8.1` run successfully.