### PR TITLE
fix: match list-valued metadata filters by item

### DIFF
--- a/packages/leann-core/src/leann/metadata_filter.py
+++ b/packages/leann-core/src/leann/metadata_filter.py
@@ -169,13 +169,15 @@ class MetadataFilterEngine:
         """Check if field value is in the expected list/collection."""
         if not isinstance(expected_value, (list, tuple, set)):
             raise ValueError("'in' operator requires a list, tuple, or set")
+        if isinstance(field_value, (list, tuple, set)):
+            return any(item in expected_value for item in field_value)
         return field_value in expected_value
 
     def _not_in(self, field_value: Any, expected_value: Any) -> bool:
         """Check if field value is not in the expected list/collection."""
         if not isinstance(expected_value, (list, tuple, set)):
             raise ValueError("'not_in' operator requires a list, tuple, or set")
-        return field_value not in expected_value
+        return not self._in(field_value, expected_value)
 
     # String operators
     def _contains(self, field_value: Any, expected_value: Any) -> bool:

--- a/tests/test_metadata_filtering.py
+++ b/tests/test_metadata_filtering.py
@@ -254,14 +254,21 @@ class TestMetadataFilterEngine:
         assert "doc1" in ids
         assert "doc5" in ids
 
-    def test_list_membership_with_nested_tags(self):
-        """Test membership operations with list metadata."""
-        # Note: This tests the metadata structure, not list field filtering
-        # For list field filtering, we'd need to modify the test data
-        filters = {"character": {"in": ["Alice"]}}
+    def test_in_filter_matches_any_list_item(self):
+        """Test that in matches when any list metadata item is allowed."""
+        filters = {"tags": {"in": ["adventure"]}}
         result = self.engine.apply_filters(self.sample_results, filters)
+
         assert len(result) == 2
-        assert all(r["metadata"]["character"] == "Alice" for r in result)
+        assert [r["id"] for r in result] == ["doc1", "doc4"]
+
+    def test_not_in_filter_rejects_any_matching_list_item(self):
+        """Test that not_in rejects list metadata containing a denied item."""
+        filters = {"tags": {"not_in": ["adventure"]}}
+        result = self.engine.apply_filters(self.sample_results, filters)
+
+        assert len(result) == 2
+        assert [r["id"] for r in result] == ["doc2", "doc3"]
 
     def test_empty_results_list(self):
         """Test filtering on empty results list."""


### PR DESCRIPTION
## What does this PR do?

Metadata filtering documents `in` as matching any requested tag, but list-valued fields were compared as one scalar value. As a result, a result tagged `adventure` failed `in: ["adventure"]` and incorrectly passed `not_in: ["adventure"]`.

This change:

- checks each item when the stored metadata value is a list, tuple, or set;
- keeps scalar membership behavior unchanged;
- makes `not_in` the exact complement while preserving its existing validation error;
- adds regression coverage for both operators using the existing list-valued `tags` fixture.

### Regression evidence

- Before the fix: `tests/test_metadata_filtering.py` failed both new assertions (`2 failed, 33 passed`).
- After the fix: the same affected suite passes (`35 passed`).

## Related Issues

No existing issue. Exact issue and PR searches for metadata filters, `not_in`, and list-valued tags found only the original merged feature work and unrelated reports.

## Checklist

- [x] Affected tests pass (`pytest tests/test_metadata_filtering.py -v --tb=short`; 35 passed)
- [x] Code formatted (`ruff format` and `ruff check` via pre-commit)
- [x] Pre-commit hooks pass (`pre-commit run --all-files`)
- [x] Type check passes (`ty check packages/leann-core/src apps tests`; 3 pre-existing warnings)
- [x] `leann-core` source distribution and wheel build successfully

The full multi-backend test matrix was not reproduced locally because the repository's CI workflow first builds and installs native backend artifacts and recursive submodules. The complete official metadata-filtering suite, repository-wide pre-commit hooks, repository-wide type check, and affected package build cover this isolated pure-Python change; CI can exercise the platform/backend matrix.
