### PR TITLE
fix(browser): honor explicit Chrome profile path

### DIFF
--- a/apps/browser_rag.py
+++ b/apps/browser_rag.py
@@ -89,16 +89,11 @@ class BrowserRAG(BaseRAGExample):
     async def load_data(self, args) -> list[dict[str, Any]]:
         """Load browser history and convert to text chunks."""
         # Determine Chrome profiles
-        if args.chrome_profile and not args.auto_find_profiles:
+        if args.chrome_profile:
             profile_dirs = [Path(args.chrome_profile)]
         else:
             print("Auto-detecting Chrome profiles...")
             profile_dirs = self._find_chrome_profiles()
-
-            # If specific profile given, filter to just that one
-            if args.chrome_profile:
-                profile_path = Path(args.chrome_profile)
-                profile_dirs = [p for p in profile_dirs if p == profile_path]
 
         if not profile_dirs:
             print("No Chrome profiles found!")


### PR DESCRIPTION
## What does this PR do?

Honor an explicitly supplied `--chrome-profile` path in `apps/browser_rag.py`.

Previously, `--auto-find-profiles` defaulted to `True`, so a custom profile path was filtered against profiles discovered under the system default Chrome directory. A valid custom profile outside that directory therefore produced `No Chrome profiles found!`.

When `--chrome-profile` is provided, this change uses it directly. Automatic profile discovery remains unchanged when no path is provided.

## Related Issues

N/A

## Validation

- `python3 -m py_compile apps/browser_rag.py`
- `uvx ruff check apps/browser_rag.py`
- `git diff --check`