### PR TITLE
fix: bind ZMQ embedding servers to loopback by default

### DIFF
--- a/packages/leann-backend-diskann/leann_backend_diskann/diskann_embedding_server.py
+++ b/packages/leann-backend-diskann/leann_backend_diskann/diskann_embedding_server.py
@@ -123,8 +123,11 @@ def create_diskann_embedding_server(
         socket = context.socket(
             zmq.REP
         )  # REP socket for both BaseSearcher and DiskANN C++ REQ clients
-        socket.bind(f"tcp://*:{zmq_port}")
-        logger.info(f"DiskANN ZMQ REP server listening on port {zmq_port}")
+        zmq_host = os.getenv("LEANN_EMBEDDING_SERVER_HOST", "127.0.0.1")
+        if ":" in zmq_host and not zmq_host.startswith("["):
+            zmq_host = f"[{zmq_host}]"  # literal IPv6 needs brackets in ZMQ endpoints
+        socket.bind(f"tcp://{zmq_host}:{zmq_port}")
+        logger.info(f"DiskANN ZMQ REP server listening on {zmq_host}:{zmq_port}")
 
         socket.setsockopt(zmq.RCVTIMEO, 1000)
         socket.setsockopt(zmq.SNDTIMEO, 1000)
@@ -260,8 +263,11 @@ def create_diskann_embedding_server(
 
         context = zmq.Context()
         rep_socket = context.socket(zmq.REP)
-        rep_socket.bind(f"tcp://*:{zmq_port}")
-        logger.info(f"DiskANN ZMQ REP server listening on port {zmq_port}")
+        zmq_host = os.getenv("LEANN_EMBEDDING_SERVER_HOST", "127.0.0.1")
+        if ":" in zmq_host and not zmq_host.startswith("["):
+            zmq_host = f"[{zmq_host}]"  # literal IPv6 needs brackets in ZMQ endpoints
+        rep_socket.bind(f"tcp://{zmq_host}:{zmq_port}")
+        logger.info(f"DiskANN ZMQ REP server listening on {zmq_host}:{zmq_port}")
 
         # Set receive timeout so we can check shutdown_event periodically
         rep_socket.setsockopt(zmq.RCVTIMEO, 1000)  # 1 second timeout

--- a/packages/leann-backend-hnsw/leann_backend_hnsw/hnsw_embedding_server.py
+++ b/packages/leann-backend-hnsw/leann_backend_hnsw/hnsw_embedding_server.py
@@ -168,8 +168,11 @@ def create_hnsw_embedding_server(
 
         context = zmq.Context()
         rep_socket = context.socket(zmq.REP)
-        rep_socket.bind(f"tcp://*:{zmq_port}")
-        logger.info(f"HNSW ZMQ REP server listening on port {zmq_port}")
+        zmq_host = os.getenv("LEANN_EMBEDDING_SERVER_HOST", "127.0.0.1")
+        if ":" in zmq_host and not zmq_host.startswith("["):
+            zmq_host = f"[{zmq_host}]"  # literal IPv6 needs brackets in ZMQ endpoints
+        rep_socket.bind(f"tcp://{zmq_host}:{zmq_port}")
+        logger.info(f"HNSW ZMQ REP server listening on {zmq_host}:{zmq_port}")
         rep_socket.setsockopt(zmq.RCVTIMEO, 1000)
         rep_socket.setsockopt(zmq.SNDTIMEO, 1000)
         rep_socket.setsockopt(zmq.LINGER, 0)


### PR DESCRIPTION
## Problem

The HNSW and DiskANN embedding servers bind their ZMQ REP sockets to `tcp://*` — all interfaces, unauthenticated. While a server is alive (any build, and every search on a recompute index), a host that can reach the port can request embedding computation and passage lookups of the indexed content. Since LEANN's pitch is privacy ("your data never leaves your laptop"), the listener shouldn't face the LAN by default.

`#303` already moved the HTTP server's default to `127.0.0.1`; this completes the same cleanup for the ZMQ side. (The wildcard bind was also briefly noted as finding M-13 inside the audit dump of #267.)

## Change

- Default bind host is now `127.0.0.1` at all three bind sites (hnsw ×1, diskann ×2).
- `LEANN_EMBEDDING_SERVER_HOST` overrides it for deliberate cross-host setups — mirroring the `LEANN_SERVER_HOST` pattern from #303. Literal IPv6 values are bracketed for the ZMQ endpoint syntax.

## Compatibility

Every in-repo client connects to `tcp://localhost:<port>` (`api.py`, `searcher_base.py`), and the DiskANN C++ REQ client receives only the port number — so a loopback bind is compatible with all consumers we could find. If the vendored DiskANN C++ side ever connects to a non-loopback self-address, the env var is the escape hatch; maintainer confirmation welcome.

## Testing

`ruff check` + `ruff format --check` (pinned 0.12.7) clean; `py_compile` on both files. The change is a bind-endpoint-only edit; behavior is otherwise identical.
