### PR TITLE
fix: force fp32 embeddings when the resolved device is CPU

### DIFF
--- a/packages/leann-core/src/leann/embedding_compute.py
+++ b/packages/leann-core/src/leann/embedding_compute.py
@@ -546,6 +546,12 @@ def compute_embeddings_sentence_transformers(
         else:
             device = "cpu"
 
+    # CPU torch ships no fp16 kernels for several ops (LayerNorm raises
+    # "LayerNormKernelImpl" not implemented for 'Half') - force fp32 on CPU.
+    if device == "cpu" and use_fp16:
+        use_fp16 = False
+        logger.info("CPU device detected: disabling fp16 (no fp16 CPU kernels)")
+
     # Apply optimizations based on benchmark results
     if adaptive_optimization:
         batch_size = _resolve_adaptive_batch_size(device, model_name)


### PR DESCRIPTION
## Problem

`compute_embeddings_sentence_transformers` loads the model with `torch_dtype=float16` whenever `use_fp16` is true — which is the default, and nothing (CLI flag, env var, provider options) ever reaches that parameter. On CPU-only machines every build and every search crashes:

```
RuntimeError: "LayerNormKernelImpl" not implemented for 'Half'
```

CPU torch ships no fp16 kernels for several ops, so sentence-transformers mode is currently unusable on CPU-only Linux (a supported install path — the README documents the `cpu` extra).

## Change

Disable fp16 when the resolved device is `cpu`, immediately after device resolution and before model construction and cache-key creation. `cuda` and `mps` keep the fp16 default.

## Verified

Reproduced on Linux x86_64, Python 3.12, `torch 2.2.2+cpu`, model `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`. With this exact guard applied, a full 39,669-chunk build plus subsequent searches ran clean on the same setup. `ruff check`/`format --check` (0.12.7) pass.
