### PR TITLE
fix(core): import the hnsw backend lazily in leann-core

### DIFF
--- a/packages/leann-core/src/leann/api.py
+++ b/packages/leann-core/src/leann/api.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import Any, Literal, Optional, Union
 
 import numpy as np
-from leann_backend_hnsw.convert_to_csr import prune_hnsw_embeddings_inplace
 
 from leann.interactive_utils import create_api_session
 from leann.interface import LeannBackendSearcherInterface
@@ -1189,6 +1188,8 @@ class LeannBuilder:
         self.chunks.clear()
 
         if needs_recompute:
+            from leann_backend_hnsw.convert_to_csr import prune_hnsw_embeddings_inplace
+
             prune_hnsw_embeddings_inplace(str(index_file))
 
 

--- a/tests/test_cpu_only_install.py
+++ b/tests/test_cpu_only_install.py
@@ -1,5 +1,6 @@
 """Packaging metadata checks for CPU-only installs."""
 
+import ast
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,21 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for Python < 3.11
 def _load_leann_pyproject():
     pyproject_path = Path(__file__).resolve().parents[1] / "packages" / "leann" / "pyproject.toml"
     return tomllib.loads(pyproject_path.read_text())
+
+
+def _leann_core_source_files():
+    package_root = Path(__file__).resolve().parents[1] / "packages" / "leann-core" / "src" / "leann"
+    return sorted(package_root.rglob("*.py"))
+
+
+def _module_scope_imports(source: str):
+    """Yield (lineno, module) for every import executed at module scope."""
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield node.lineno, alias.name
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            yield node.lineno, node.module
 
 
 def _load_leann_core_pyproject():
@@ -59,3 +75,26 @@ def test_leann_cpu_extra_defined():
 
     assert "cpu" in extras
     assert "leann-core[cpu]>=0.1.0" in extras["cpu"]
+
+
+def test_leann_core_does_not_import_a_backend_at_module_scope():
+    """leann-core declares no leann-backend-* dependency, so importing one eagerly
+    turns `import leann` into a ModuleNotFoundError for anyone who installed
+    leann-core on its own or paired it with a non-HNSW backend."""
+    data = _load_leann_core_pyproject()
+    deps = data["project"].get("dependencies", [])
+    assert not any(dep.startswith("leann-backend") for dep in deps), (
+        "leann-core now depends on a backend; this test needs revisiting"
+    )
+
+    offenders = [
+        f"{path.name}:{lineno} imports {module}"
+        for path in _leann_core_source_files()
+        for lineno, module in _module_scope_imports(path.read_text(encoding="utf-8"))
+        if module.split(".")[0].startswith("leann_backend")
+    ]
+
+    assert not offenders, (
+        "leann-core must import backends lazily inside the functions that use them: "
+        + "; ".join(offenders)
+    )


### PR DESCRIPTION
## What does this PR do?

`import leann` raises `ModuleNotFoundError` on a plain `pip install leann-core`.

`packages/leann-core/src/leann/api.py:20` imports the HNSW backend at module scope:

```python
from leann_backend_hnsw.convert_to_csr import prune_hnsw_embeddings_inplace
```

but `packages/leann-core/pyproject.toml` declares no `leann-backend-*` dependency — `leann-core` is the plugin host, and `registry.autodiscover_backends()` is supposed to find backends at runtime. Since `leann/__init__.py:27` does `from .api import LeannBuilder, LeannChat, LeannSearcher`, that one line makes the whole distribution unimportable whenever `leann-backend-hnsw` is absent, and takes both console scripts (`leann`, `leann_mcp`) down with it. It affects anyone pairing `leann-core` with a non-HNSW backend, and anyone following `docs/configuration-guide.md:321` (`pip install "leann-core[litellm]"`). The umbrella `leann` package pulls HNSW in, which is why this has stayed hidden.

The symbol has exactly one call site, `api.py:1192`, inside the HNSW branch of `update_index` — 136 lines after `from leann_backend_hnsw import faiss` at `api.py:1056` has already established that the backend is present. Every other backend reference in the file is already function-local (`api.py:914`, `api.py:1011`, `api.py:1056`), so line 20 was the odd one out. This moves it to the call site, matching that convention.

### Reproduction

Against the published wheel, clean Python 3.12 venv, `leann-core` and its declared dependencies only:

```
$ uv pip install leann-core
$ python -c "import importlib.metadata as md; d=md.distribution('leann-core'); \
    rd=d.metadata.get_all('Requires-Dist'); print(d.version, len(rd), \
    [r for r in rd if 'leann-backend' in r] or 'no backend dep')"
0.3.7 33 no backend dep

$ python -c "import leann"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../site-packages/leann/__init__.py", line 27, in <module>
    from .api import LeannBuilder, LeannChat, LeannSearcher
  File ".../site-packages/leann/api.py", line 20, in <module>
    from leann_backend_hnsw.convert_to_csr import prune_hnsw_embeddings_inplace
ModuleNotFoundError: No module named 'leann_backend_hnsw'

$ leann --help
  ... same traceback
```

Same venv with this branch's `leann-core` installed:

```
$ python -c "import leann; print('import leann OK')"
import leann OK

$ leann --help
usage: leann [-h] [-v | -q]
             {build,watch,migrate-ids,rebuild,search,warmup,daemon,ask,...}
```

### Regression coverage

`tests/test_cpu_only_install.py` is the existing home for packaging-metadata checks, so the new test lives there. It AST-parses every module under `packages/leann-core/src/leann` and asserts that no import executed at module scope names a `leann_backend_*` module, guarded by a check that `leann-core` still declares no backend dependency. Imports inside functions are unaffected, so the lazy pattern the file already uses stays legal.

This is deliberately a static check rather than a runtime import: `tests/test_ci_minimal.py:42-44` imports `leann`, `leann_backend_diskann` and `leann_backend_hnsw` together, so the coupling is always satisfied in CI and a runtime assertion would pass with or without the fix.

Before the fix (`git stash` on `api.py` only):

```
$ pytest tests/test_cpu_only_install.py -q
tests/test_cpu_only_install.py ....F                                     [100%]
=================================== FAILURES ===================================
__________ test_leann_core_does_not_import_a_backend_at_module_scope ___________
E   AssertionError: leann-core must import backends lazily inside the functions
E   that use them: api.py:20 imports leann_backend_hnsw.convert_to_csr
=================== 1 failed, 4 passed, 2 warnings in 0.05s ====================
```

After:

```
$ pytest tests/test_cpu_only_install.py -q
tests/test_cpu_only_install.py .....                                     [100%]
======================== 5 passed, 2 warnings in 0.04s =========================
```

## Related Issues

No existing issue. Searched issues and PRs for `leann_backend_hnsw` and for `leann-core` dependency reports; nothing matched. The import arrived in `5f7806e` ("Introducing dynamic index update (#108)") and has not been revisited since.

## Checklist

- [x] Code formatted (`ruff format --check .` — 173 files already formatted; `ruff check .` — all checks passed)
- [x] Type check unchanged (`ty check packages/leann-core/src tests` — 35 diagnostics, identical to `upstream/main`)
- [x] `pytest tests/test_cpu_only_install.py` passes (5 passed)
