### PR TITLE
fix: recover from corrupt sync snapshots

### DIFF
--- a/packages/leann-core/src/leann/sync.py
+++ b/packages/leann-core/src/leann/sync.py
@@ -299,3 +299,13 @@ class FileSynchronizer:
                 self.tree = pickle.load(f)
         except FileNotFoundError:
             self.tree = None
+        except (
+            OSError,
+            EOFError,
+            pickle.UnpicklingError,
+            AttributeError,
+            ImportError,
+            IndexError,
+        ) as exc:
+            logger.warning("Cannot load sync snapshot %s: %s", self.snapshot_path, exc)
+            self.tree = None

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -56,6 +56,24 @@ class TestMerkleTreeCompare(unittest.TestCase):
 
 
 class TestFileSynchronizer(unittest.TestCase):
+    def test_corrupt_snapshot_is_rebuilt(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            document = root / "file.txt"
+            document.write_text("hello world", encoding="utf-8")
+            snapshot = root / "sync.pickle"
+            snapshot.write_bytes(b"truncated pickle")
+
+            synchronizer = FileSynchronizer(
+                root_dir=temp_dir,
+                snapshot_path=str(snapshot),
+            )
+
+            added, removed, modified = synchronizer.detect_changes()
+            assert added == [str(document.resolve())]
+            assert removed == []
+            assert modified == []
+
     def test_generate_file_hashes(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             file_path = Path(temp_dir) / "file.txt"


### PR DESCRIPTION
## What does this PR do?

A truncated or incompatible sync snapshot currently aborts initialization during `pickle.load`. Since the snapshot is a cache, the synchronizer can recover by rebuilding it from the source directory.

This change catches the standard deserialization and I/O failures, logs a warning, and resets the cached tree. A regression test writes a truncated pickle and verifies that the existing source file is detected as newly added.

## Related Issues

None.

## Checklist

- [x] Focused test passes: `pytest --noconftest tests/test_sync.py::TestFileSynchronizer::test_corrupt_snapshot_is_rebuilt -q`
- [x] Code formatted (`ruff format` and `ruff check`)
- [x] Pre-commit hooks pass (CI)