### PR TITLE
fix(mcp): answer `ping` with an empty result, not -32601

### DIFF
--- a/packages/leann-core/src/leann/mcp.py
+++ b/packages/leann-core/src/leann/mcp.py
@@ -340,6 +340,18 @@ def handle_request(request):
     if method == "notifications/initialized":
         return None
 
+    if method == "ping":
+        # MCP requires a ping request to be answered with an empty result.
+        # Without this it falls through to the -32601 branch below, which tells
+        # a client its liveness probe is unsupported — a different wrong answer
+        # from the silence #384 fixed, but still one that breaks keepalives
+        # (issue #403).
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": {},
+        }
+
     if method == "tools/list":
         return {
             "jsonrpc": "2.0",

--- a/tests/test_mcp_dispatch.py
+++ b/tests/test_mcp_dispatch.py
@@ -1,0 +1,38 @@
+"""JSON-RPC dispatch rules for the MCP server (see issue #403).
+
+#384 stopped unknown *requests* from being answered with silence, which was
+the cause of the client respawn loops. `ping` is not an unknown method though:
+it is a required MCP utility, and the spec says a ping request is answered with
+an empty result. Answering it with -32601 tells a client its liveness probe is
+unsupported, which is a different wrong answer from the original silence.
+"""
+
+from leann.mcp import handle_request
+
+
+def test_ping_returns_an_empty_result():
+    response = handle_request({"jsonrpc": "2.0", "id": 3, "method": "ping"})
+
+    assert response is not None, "silence is what caused the respawn loops"
+    assert response["id"] == 3
+    assert response["result"] == {}
+    assert "error" not in response
+
+
+def test_ping_with_params_is_still_a_ping():
+    response = handle_request({"jsonrpc": "2.0", "id": 4, "method": "ping", "params": {}})
+
+    assert response["result"] == {}
+
+
+def test_unknown_request_still_gets_method_not_found():
+    """#384's behaviour must survive: an unknown request is an error, not silence."""
+    response = handle_request({"jsonrpc": "2.0", "id": 9, "method": "server/discover"})
+
+    assert response["error"]["code"] == -32601
+
+
+def test_notifications_get_no_response():
+    """JSON-RPC 2.0: a notification has no id and must never be answered."""
+    assert handle_request({"jsonrpc": "2.0", "method": "notifications/initialized"}) is None
+    assert handle_request({"jsonrpc": "2.0", "method": "some/unknown/notification"}) is None


### PR DESCRIPTION
Closes #403.

## What was actually left

#384 stopped unknown requests being answered with silence, which was the cause of the respawn loops in #403 — a client whose liveness probe got no reply read the transport as dead and killed the subprocess. The reporter was on `leann-core` 0.3.7, which predates that fix, so **that half of the report is already fixed on `main`**.

`ping` is still wrong, though, just less visibly. It is not an unknown method: MCP requires a ping request to be answered with an empty result. Falling through to the `-32601` branch tells the client its keepalive is *unsupported* — a different wrong answer from silence, and one that still breaks liveness checks.

Before this change, on current `main`:

```
ping -> {'jsonrpc': '2.0', 'id': 3, 'error': {'code': -32601, 'message': 'Method not found'}}
```

After:

```
initialize                -> {'jsonrpc': '2.0', 'id': 1, 'result': {...}}
notifications/initialized -> (no response — correct for a notification)
ping                      -> {'jsonrpc': '2.0', 'id': 3, 'result': {}}
```

That is the issue's own reproduction sequence.

## Tests

New `tests/test_mcp_dispatch.py`, written against the old dispatcher first — the two ping tests were red, the two guards below were already green:

- `ping` returns an empty result, with and without `params`
- an unknown **request** still gets `-32601` (pins #384's behaviour)
- a **notification** (no `id`) still gets no reply at all (JSON-RPC 2.0)

`ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
