### PR TITLE
docs: document LEANN_EMBEDDING_SERVER_HOST

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -102,6 +102,30 @@ export LEANN_OLLAMA_HOST="http://localhost:11434"   # falls back to OLLAMA_HOST 
 
 LEANN also recognises `LEANN_LOCAL_LLM_HOST` (highest priority), `LEANN_OPENAI_BASE_URL`, and `LOCAL_OPENAI_BASE_URL`, so existing scripts continue to work.
 
+### Embedding Server Bind Address
+
+The backend embedding servers (HNSW and DiskANN) listen on `127.0.0.1` by
+default, so an index build or search does not expose an embedding endpoint to
+the rest of the network. Override the bind address only when something outside
+the machine genuinely needs to reach it — a container sidecar, or a searcher on
+another host:
+
+```bash
+# Listen on every interface (containers, cross-host setups)
+export LEANN_EMBEDDING_SERVER_HOST="0.0.0.0"
+
+# Or bind one specific interface
+export LEANN_EMBEDDING_SERVER_HOST="10.0.0.5"
+
+# IPv6 works too; brackets are added automatically
+export LEANN_EMBEDDING_SERVER_HOST="::1"
+```
+
+The server speaks an unauthenticated ZMQ REP protocol, so anything that can
+reach the port can request embeddings. Prefer the loopback default, and if you
+must widen it, restrict access at the firewall or container network rather than
+exposing the port publicly.
+
 ### Passing Hosts Per Command
 
 ```bash


### PR DESCRIPTION
Follow-up to #404.

That PR changed the HNSW and DiskANN embedding servers to bind `127.0.0.1` instead of `tcp://*`, and added `LEANN_EMBEDDING_SERVER_HOST` as the escape hatch. The variable was never documented — `grep -rn LEANN_EMBEDDING_SERVER_HOST --include="*.md"` returned nothing — so a container or cross-host deployment breaks on upgrade with no discoverable way to restore the previous behaviour.

Adds an **Embedding Server Bind Address** section to the configuration guide covering:

- the loopback default and why it exists
- how to widen it (`0.0.0.0`, a specific interface, IPv6 — brackets handled automatically by #404)
- that the ZMQ REP protocol is unauthenticated, so reachability *is* authorisation — widening it should be paired with a firewall or container-network restriction

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
