### PR TITLE
fix: preserve mixed-script token boundaries in BM25 search

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,3 +66,8 @@ fixes). Newest entries at the bottom.
   already-working Windows `cp314` installs. Completing the wheel matrix is the
   correct fix; the next 0.3.8 patch release will carry full `cp314` coverage
   once CI confirms the new platforms build cleanly.
+
+## 2026-09-06: Preserve mixed-script words in BM25 search
+
+- Keep Latin words and numbers separate from adjacent Chinese, Japanese, and Korean n-grams when building SQLite FTS5 indexes and parsing keyword queries. For example, `Python数据库SQL` can be retrieved by `Python`, `SQL`, or a mixed-script query.
+- Existing BM25 artifacts remain readable. Rebuild indexes containing mixed-script text to regenerate tokens that were previously joined at script boundaries.

--- a/packages/leann-core/src/leann/api.py
+++ b/packages/leann-core/src/leann/api.py
@@ -45,12 +45,15 @@ _CJK_RUN = re.compile(f"[{_CJK_CHARACTERS}]+")
 def _fts5_cjk_ngrams(match: re.Match[str]) -> str:
     """Expand a CJK run into unigram and bigram tokens for SQLite FTS5."""
     text = match.group()
-    return " ".join([*text, *(text[i : i + 2] for i in range(len(text) - 1))])
+    tokens = " ".join([*text, *(text[i : i + 2] for i in range(len(text) - 1))])
+    # Keep adjacent non-CJK words separate from the first and last n-grams.
+    return f" {tokens} "
 
 
 def _fts5_cjk_query(query: str) -> str:
     """Build a safe FTS5 query that requires every CJK bigram in each term."""
-    tokens = re.findall(rf"[{_CJK_CHARACTERS}]+|\w+", query.lower())
+    # Unicode \w includes CJK, so exclude it from the non-CJK alternative.
+    tokens = re.findall(rf"[{_CJK_CHARACTERS}]+|[^\W{_CJK_CHARACTERS}]+", query.lower())
     terms = []
     for token in tokens:
         if _CJK_RUN.fullmatch(token):

--- a/tests/test_fts5_bm25.py
+++ b/tests/test_fts5_bm25.py
@@ -1,3 +1,4 @@
+import pytest
 from leann.api import Fts5BM25Index
 
 
@@ -28,5 +29,47 @@ def test_fts5_bm25_keeps_legacy_database_query_format(tmp_path):
     reopened = Fts5BM25Index(str(db_path))
     try:
         assert [result.id for result in reopened.search("database")] == ["database"]
+    finally:
+        reopened.close()
+
+
+@pytest.mark.parametrize("cjk_text", ["数据库", "データベース", "데이터베이스"])
+@pytest.mark.parametrize("query", ["Python", "SQL"])
+def test_fts5_bm25_preserves_words_adjacent_to_cjk(tmp_path, cjk_text, query):
+    db_path = tmp_path / "mixed.sqlite"
+    index = Fts5BM25Index(str(db_path))
+    index.fit(
+        [
+            {"id": "mixed", "text": f"Python{cjk_text}SQL"},
+            {"id": "unrelated", "text": "unrelated document"},
+        ]
+    )
+    index.close()
+
+    reopened = Fts5BM25Index(str(db_path))
+    try:
+        assert [result.id for result in reopened.search(query)] == ["mixed"]
+    finally:
+        reopened.close()
+
+
+@pytest.mark.parametrize("query", ["Python数据库", "数据库Python", "Python数据库SQL", "2026数据库"])
+def test_fts5_bm25_splits_mixed_script_query_terms(tmp_path, query):
+    db_path = tmp_path / "queries.sqlite"
+    index = Fts5BM25Index(str(db_path))
+    index.fit(
+        [
+            {"id": "database", "text": "数据库检索系统"},
+            {"id": "partial", "text": "数据分析"},
+            {"id": "unrelated", "text": "image classification"},
+        ]
+    )
+    index.close()
+
+    reopened = Fts5BM25Index(str(db_path))
+    try:
+        # Match the CJK term independently of the Latin/number terms, while
+        # still requiring all its bigrams (the partial match must be excluded).
+        assert [result.id for result in reopened.search(query)] == ["database"]
     finally:
         reopened.close()


### PR DESCRIPTION

### What does this PR do?

Fixes BM25 retrieval of mixed Chinese/Japanese/Korean and Latin text. A passage such as `Python数据库SQL` currently fails searches for `Python` and `SQL` because n-gram expansion joins those words to the edge n-grams. Mixed queries such as `Python数据库` also fail because Unicode `\w` consumes both scripts.

Add boundaries around indexed CJK n-grams and keep CJK runs separate when parsing query terms. Existing OR-between-terms and AND-between-CJK-bigrams semantics are preserved. Extend the FTS5 tests with mixed-script retrieval after database reopen and negative controls.

Previously built artifacts remain readable; affected indexes need rebuilding to regenerate missing tokens. No new dependency or public API change.

### Related Issues

Follow-up correctness fix to merged #401. No matching open issue or competing open PR was found. Does not address the metadata-sharing/incremental work in open #398.

### Validation

- Nine regression cases fail on the base production code.
- 47 focused FTS5 and metadata-filter tests pass with the fix.
- Changed-file Ruff and pre-commit checks pass; repository-wide formatting passes.
- Whole-repository Ruff has seven pre-existing errors in untouched CLI code; targeted ty reports four unchanged baseline diagnostics.
- Full runtime/CI matrix not run.

AI assistance: implemented and tested with Codex (GPT-6); no claim of human review is made here.

## Checklist

- [ ] Full test suite (`uv run pytest`); focused 47-test suite passed.
- [ ] Repository-wide lint clean; seven baseline CLI errors remain. Formatting and changed-file lint passed.
- [ ] Full pre-commit run; changed-file applicable hooks passed.


### CI follow-up

The [lint job](https://github.com/StarTrail-org/LEANN/actions/runs/34018030058/job/101445265467) reports exactly the seven pre-existing `F811` duplicate `index_*` methods in `cli.py` documented above. Formatting passes. None of the errors is in the tokenizer or regression tests, and the same diagnostics were verified on the base. This PR leaves those handlers unchanged.
